### PR TITLE
chore: remove unused Axios type extension for InternalAxiosRequestConfig

### DIFF
--- a/dist/base-factory.d.ts
+++ b/dist/base-factory.d.ts
@@ -129,12 +129,3 @@ export declare const VI: {
 };
 
 export { }
-
-
-declare module 'axios' {
-    interface InternalAxiosRequestConfig {
-        metadata?: {
-            startTime: number;
-        };
-    }
-}


### PR DESCRIPTION
This commit eliminates the previously defined extension for InternalAxiosRequestConfig in the Axios module, streamlining the type definitions in the project. This change helps maintain clarity and reduces unnecessary complexity in the codebase.